### PR TITLE
add nostack dockerfile

### DIFF
--- a/Dockerfile.nostack
+++ b/Dockerfile.nostack
@@ -1,0 +1,24 @@
+ARG STACK_VERSION=lts-13
+FROM fpco/stack-build:$STACK_VERSION as builder
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y clang \
+    && git clone https://github.com/carp-lang/carp . \
+    && stack build && stack install && stack clean \
+    && mv /root/.local/bin /app/bin \
+    && rm -rf /app/.stack-work/install
+
+
+FROM ubuntu:16.04
+
+COPY --from=builder /app /opt/carp
+
+ENV CARP_DIR=/opt/carp/
+ENV PATH=$PATH:"${CARP_DIR}bin"
+
+RUN apt-get update && apt-get install -y clang libgmp10
+
+WORKDIR $CARP_DIR
+
+CMD ["carp"]


### PR DESCRIPTION
Original image size is prohibitively large for slow connection (11G) so I added a new one without Stack(less than 200mb + like 300mb from clang package, mb we can find a smaller package?).  It seems to work but I'm not too familiar with carp to test it in depth.

`docker build -t carp -f Dockerfile.nostack .`
`docker run -ti --rm carp`

- - - - - - - - -

It would be great if you can setup DockerHub autobuild  https://docs.docker.com/docker-hub/builds so ppl will have to download only final image.