### PR TITLE
For some reason it now requires libncurses-dev to operate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV CARP_DIR=/opt/carp/
 ENV PATH=$PATH:"${CARP_DIR}bin"
 
 RUN apt-get update \
-    && apt-get install -y clang libgmp10 libtinfo5 --no-install-recommends \
+    && apt-get install -y clang libgmp10 libtinfo5 libncurses-dev --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /mnt/app

--- a/Dockerfile.emcc
+++ b/Dockerfile.emcc
@@ -3,7 +3,8 @@ FROM fpco/stack-build:$STACK_VERSION as builder
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y clang --no-install-recommends \
+RUN apt-get update \
+    && apt-get install -y clang libncurses-dev --no-install-recommends \
     && git clone https://github.com/carp-lang/carp . \
     && stack build && stack install && stack clean \
     && mv /root/.local/bin /app/bin \


### PR DESCRIPTION
I was unable to execute the docker images using the provided instructions due to a missing libtinfo development header. Adding libncurses-dev appears to resolve this issue.